### PR TITLE
Add --specimen and --aggregate-only modes for specimux-suite integration (0.7.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.7] - 2026-03-17
+
+### Added
+- **`--specimen` flag** (summarize) — Process only a single specimen, outputting per-specimen files and a JSON summary to stdout. Designed for incremental invocation by specimux-suite orchestration layer
+- **`--aggregate-only` flag** (summarize) — Regenerate aggregate `summary.fasta` from existing per-specimen outputs without reprocessing. Parses metadata (`raw_ric`, `raw_len`, `snp_count`) back from FASTA headers for full-fidelity reconstruction
+
+### Fixed
+- **Stale output file cleanup** — Single-specimen mode removes previous output files before reprocessing to prevent accumulation when variant counts change between runs
+- **Temp log file leak** — Early-return paths (e.g., no sequences found) now clean up the temporary log file
+- **Glob escaping in specimen cleanup** — Specimen IDs containing glob metacharacters no longer match unintended files
+
 ## [0.7.6] - 2026-02-08
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,3 +179,9 @@ The `scripts/` directory (git-ignored) contains local development utilities:
 - `verify_refactor_at_commit.py`: Same verification against specific git commits
 
 These scripts compare original monolithic files against refactored subpackages to detect transcription errors. Useful for future refactoring work.
+
+## Integration with specimux-suite
+
+See `~/mm/code/specimux-suite/INTEGRATION.md` for integration contracts with specimux-suite, including:
+- Profile system (`-p/--profile`, `--list-profiles`) — profiles in `~/.config/speconsense/profiles/` and bundled
+- Subprocess invocation contract — how specimux-suite constructs speconsense commands

--- a/docs/profile-parameters.md
+++ b/docs/profile-parameters.md
@@ -123,4 +123,4 @@ Profiles specify a `speconsense-version` field (e.g., `"0.7.*"`) indicating comp
 
 ---
 
-*Document generated for speconsense 0.7.6*
+*Document generated for speconsense 0.7.7*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speconsense"
-version = "0.7.6"
+version = "0.7.7"
 description = "High-quality clustering and consensus generation for Oxford Nanopore amplicon reads"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/speconsense/__init__.py
+++ b/speconsense/__init__.py
@@ -5,7 +5,7 @@ A Python tool for experimental clustering and consensus generation as an alterna
 in the fungal DNA barcoding pipeline.
 """
 
-__version__ = "0.7.6"
+__version__ = "0.7.7"
 __author__ = "Josh Walker"
 __email__ = "joshowalker@yahoo.com"
 

--- a/speconsense/summarize/cli.py
+++ b/speconsense/summarize/cli.py
@@ -3,7 +3,10 @@
 Provides argument parsing, logging setup, and main entry point.
 """
 
+import glob
+import json
 import os
+import shutil
 import sys
 import argparse
 import logging
@@ -49,6 +52,7 @@ from speconsense.types import ConsensusInfo, OverlapMergeInfo
 from .fields import parse_fasta_fields
 from .io import (
     load_consensus_sequences,
+    load_existing_specimen_outputs,
     build_fastq_lookup_table,
     write_specimen_data_files,
     write_output_files,
@@ -104,6 +108,10 @@ def parse_arguments():
                           help="Source directory containing Speconsense output (default: clusters)")
     io_group.add_argument("--summary-dir", type=str, default="__Summary__",
                           help="Output directory for summary files (default: __Summary__)")
+    io_group.add_argument("--specimen", type=str, default=None,
+                          help="Process only this specimen. Loads only <specimen>-all.fasta from --source.")
+    io_group.add_argument("--aggregate-only", action="store_true",
+                          help="Skip processing. Generate aggregate summary from existing per-specimen outputs.")
     io_group.add_argument("--fasta-fields", type=str, default="default",
                           help="FASTA header fields to output. Can be: "
                                "(1) a preset name (default, minimal, qc, full, id-only), "
@@ -241,6 +249,10 @@ def parse_arguments():
         if '--snp-merge-limit' in sys.argv:
             logging.warning("--snp-merge-limit is deprecated, use --merge-position-count instead")
         args.merge_position_count = args._snp_merge_limit_deprecated
+
+    # Validate mutual exclusion of --specimen and --aggregate-only
+    if args.specimen and args.aggregate_only:
+        parser.error("--specimen and --aggregate-only are mutually exclusive")
 
     if '--variant-group-identity' in sys.argv:
         logging.warning("--variant-group-identity is deprecated, use --group-identity instead")
@@ -430,6 +442,40 @@ def process_single_specimen(file_consensuses: List[ConsensusInfo],
     return final_consensus, all_merge_traceability, naming_info, total_limited_count, all_overlap_merges
 
 
+def _clean_specimen_output(summary_dir: str, specimen_id: str) -> None:
+    """Remove previous output files for a specimen before reprocessing.
+
+    Cleans files matching {specimen_id}* from summary_dir and its subdirs
+    to prevent stale files from accumulating when variant counts change.
+    """
+    dirs_to_clean = [
+        summary_dir,
+        os.path.join(summary_dir, 'FASTQ Files'),
+        os.path.join(summary_dir, 'variants'),
+        os.path.join(summary_dir, 'variants', 'FASTQ Files'),
+    ]
+    removed = 0
+    for d in dirs_to_clean:
+        if not os.path.exists(d):
+            continue
+        for f in glob.glob(os.path.join(d, f"{glob.escape(specimen_id)}*")):
+            try:
+                os.unlink(f)
+                removed += 1
+            except OSError as e:
+                logging.warning(f"Could not remove stale file {f}: {e}")
+    if removed:
+        logging.info(f"Cleaned {removed} previous output files for {specimen_id}")
+
+
+def _cleanup_log(log_path: str) -> None:
+    """Clean up temporary log file."""
+    try:
+        os.unlink(log_path)
+    except Exception as e:
+        logging.debug(f"Could not clean up temporary log file: {e}")
+
+
 def main():
     """Main function to process command line arguments and run the summarization."""
     args = parse_arguments()
@@ -482,14 +528,38 @@ def main():
     logging.info(f"  --enable-full-consensus: {args.enable_full_consensus}")
     logging.info(f"  --log-level: {args.log_level}")
     logging.info("")
+
+    # --- Aggregate-only mode ---
+    if args.aggregate_only:
+        logging.info("Aggregate-only mode: generating summary from existing per-specimen outputs")
+        all_final_consensus = load_existing_specimen_outputs(args.summary_dir)
+        if not all_final_consensus:
+            logging.error("No existing specimen outputs found in summary directory")
+            _cleanup_log(temp_log_file.name)
+            return
+
+        write_output_files(
+            all_final_consensus,
+            [],  # no raw consensuses available in aggregate mode
+            args.summary_dir,
+            temp_log_file.name,
+            fasta_fields
+        )
+
+        logging.info(f"Aggregate summary complete: {len(all_final_consensus)} sequences")
+        _cleanup_log(temp_log_file.name)
+        return
+
     logging.info("Processing each specimen file independently to organize variants within specimens")
 
-    # Load all consensus sequences
+    # Load consensus sequences (optionally filtered to single specimen)
     consensus_list = load_consensus_sequences(
-        args.source, args.min_ric, args.min_len, args.max_len
+        args.source, args.min_ric, args.min_len, args.max_len,
+        specimen_id=args.specimen
     )
     if not consensus_list:
         logging.error("No consensus sequences found")
+        _cleanup_log(temp_log_file.name)
         return
 
     # Group consensus sequences by input file (one file per specimen)
@@ -502,6 +572,10 @@ def main():
     os.makedirs(os.path.join(args.summary_dir, 'FASTQ Files'), exist_ok=True)
     os.makedirs(os.path.join(args.summary_dir, 'variants'), exist_ok=True)
     os.makedirs(os.path.join(args.summary_dir, 'variants', 'FASTQ Files'), exist_ok=True)
+
+    # In single-specimen mode, clean previous output for this specimen
+    if args.specimen:
+        _clean_specimen_output(args.summary_dir, args.specimen)
 
     # Build lookup tables once before processing loop
     fastq_lookup = build_fastq_lookup_table(args.source)
@@ -549,6 +623,26 @@ def main():
             unique_key = f"{file_name}_{group_id}"
             all_naming_info[unique_key] = group_naming
 
+    # --- Single-specimen mode: print JSON to stdout, skip aggregate files ---
+    if args.specimen:
+        variants = []
+        for cons in all_final_consensus:
+            variants.append({
+                "name": cons.sample_name,
+                "ric": cons.ric,
+                "size": cons.size,
+                "length": len(cons.sequence),
+            })
+        result = {
+            "specimen_id": args.specimen,
+            "variant_count": len(variants),
+            "variants": variants,
+        }
+        print(json.dumps(result))
+        logging.info(f"Single-specimen mode complete: {len(variants)} variants for {args.specimen}")
+        _cleanup_log(temp_log_file.name)
+        return
+
     # Write summary files at end (after all processing)
     write_output_files(
         all_final_consensus,
@@ -576,11 +670,7 @@ def main():
     if total_limited_merges > 0:
         logging.info(f"Note: {total_limited_merges} variant group(s) had >{MAX_MSA_MERGE_VARIANTS} variants (results potentially suboptimal)")
 
-    # Clean up temporary log file
-    try:
-        os.unlink(temp_log_file.name)
-    except Exception as e:
-        logging.debug(f"Could not clean up temporary log file: {e}")
+    _cleanup_log(temp_log_file.name)
 
 
 if __name__ == "__main__":

--- a/speconsense/summarize/io.py
+++ b/speconsense/summarize/io.py
@@ -24,18 +24,19 @@ from .clustering import select_variants
 
 
 def parse_consensus_header(header: str) -> Tuple[Optional[str], Optional[int], Optional[int],
-                                                   Optional[List[str]], Optional[float], Optional[float]]:
+                                                   Optional[List[str]], Optional[float], Optional[float],
+                                                   Optional[List[int]], Optional[List[int]], Optional[int]]:
     """
     Extract information from Speconsense consensus FASTA header.
 
-    Parses read identity metrics.
+    Parses read identity metrics and merge metadata.
 
     Returns:
-        Tuple of (sample_name, ric, size, primers, rid, rid_min)
+        Tuple of (sample_name, ric, size, primers, rid, rid_min, raw_ric, raw_len, snp_count)
     """
     sample_match = re.match(r'>([^ ]+) (.+)', header)
     if not sample_match:
-        return None, None, None, None, None, None
+        return None, None, None, None, None, None, None, None, None
 
     sample_name = sample_match.group(1)
     info_string = sample_match.group(2)
@@ -59,22 +60,34 @@ def parse_consensus_header(header: str) -> Tuple[Optional[str], Optional[int], O
     rid_min_match = re.search(r'rid_min=([\d.]+)', info_string)
     rid_min = float(rid_min_match.group(1)) / 100.0 if rid_min_match else None
 
-    return sample_name, ric, size, primers, rid, rid_min
+    # Extract merge metadata (plus-delimited lists)
+    rawric_match = re.search(r'rawric=(\d+(?:\+\d+)*)', info_string)
+    raw_ric = [int(x) for x in rawric_match.group(1).split('+')] if rawric_match else None
+
+    rawlen_match = re.search(r'rawlen=(\d+(?:\+\d+)*)', info_string)
+    raw_len = [int(x) for x in rawlen_match.group(1).split('+')] if rawlen_match else None
+
+    snp_match = re.search(r'snp=(\d+)', info_string)
+    snp_count = int(snp_match.group(1)) if snp_match else None
+
+    return sample_name, ric, size, primers, rid, rid_min, raw_ric, raw_len, snp_count
 
 
 def load_consensus_sequences(
     source_folder: str,
     min_ric: int,
     min_len: int = 0,
-    max_len: int = 0
+    max_len: int = 0,
+    specimen_id: str = None
 ) -> List[ConsensusInfo]:
-    """Load all consensus sequences from speconsense output files.
+    """Load consensus sequences from speconsense output files.
 
     Args:
         source_folder: Directory containing speconsense output files
         min_ric: Minimum Reads in Consensus threshold
         min_len: Minimum sequence length (0 = disabled)
         max_len: Maximum sequence length (0 = disabled)
+        specimen_id: If set, load only {specimen_id}-all.fasta instead of all
 
     Returns:
         List of ConsensusInfo objects passing all filters
@@ -83,8 +96,11 @@ def load_consensus_sequences(
     filtered_by_ric = 0
     filtered_by_len = 0
 
-    # Find all consensus FASTA files matching the new naming pattern
-    fasta_pattern = os.path.join(source_folder, "*-all.fasta")
+    # Find consensus FASTA files — narrow to single specimen if requested
+    if specimen_id:
+        fasta_pattern = os.path.join(source_folder, f"{specimen_id}-all.fasta")
+    else:
+        fasta_pattern = os.path.join(source_folder, "*-all.fasta")
     fasta_files = sorted(glob.glob(fasta_pattern))
 
     for fasta_file in fasta_files:
@@ -92,7 +108,7 @@ def load_consensus_sequences(
 
         with open(fasta_file, 'r') as f:
             for record in SeqIO.parse(f, "fasta"):
-                sample_name, ric, size, primers, rid, rid_min = \
+                sample_name, ric, size, primers, rid, rid_min, _, _, _ = \
                     parse_consensus_header(f">{record.description}")
 
                 if not sample_name:
@@ -659,6 +675,55 @@ def write_position_debug_file(
                 f.write("\n")
 
     logging.info(f"Position error debug file written to: {debug_path}")
+
+
+def load_existing_specimen_outputs(summary_dir: str) -> List[ConsensusInfo]:
+    """Load per-specimen FASTA outputs for aggregate-only mode.
+
+    Scans summary_dir for individual specimen FASTA files (excluding summary.fasta),
+    reconstructing ConsensusInfo objects from their headers.
+
+    Returns:
+        List of ConsensusInfo objects from existing per-specimen files
+    """
+    consensus_list = []
+    fasta_pattern = os.path.join(summary_dir, "*.fasta")
+    fasta_files = sorted(glob.glob(fasta_pattern))
+
+    for fasta_file in fasta_files:
+        basename = os.path.basename(fasta_file)
+        if basename == "summary.fasta":
+            continue
+
+        with open(fasta_file, 'r') as f:
+            for record in SeqIO.parse(f, "fasta"):
+                sample_name, ric, size, primers, rid, rid_min, raw_ric, raw_len, snp_count = \
+                    parse_consensus_header(f">{record.description}")
+
+                if not sample_name:
+                    continue
+
+                cluster_match = re.search(r'-c(\d+)$', sample_name)
+                cluster_id = cluster_match.group(0) if cluster_match else sample_name
+
+                consensus_info = ConsensusInfo(
+                    sample_name=sample_name,
+                    cluster_id=cluster_id,
+                    sequence=str(record.seq),
+                    ric=ric,
+                    size=size,
+                    file_path=fasta_file,
+                    snp_count=snp_count,
+                    primers=primers,
+                    raw_ric=raw_ric,
+                    raw_len=raw_len,
+                    rid=rid,
+                    rid_min=rid_min,
+                )
+                consensus_list.append(consensus_info)
+
+    logging.info(f"Loaded {len(consensus_list)} existing sequences from {len(fasta_files)} files in {summary_dir}")
+    return consensus_list
 
 
 def write_output_files(final_consensus: List[ConsensusInfo],


### PR DESCRIPTION
Enables incremental per-specimen processing and aggregate-only summary regeneration, designed for orchestration by specimux-suite. Fixes glob escaping in specimen cleanup, temp log file leak on early returns, and recovers merge metadata (raw_ric, raw_len, snp_count) in aggregate mode.